### PR TITLE
Update tools.dat

### DIFF
--- a/data/tools.dat
+++ b/data/tools.dat
@@ -25,13 +25,11 @@ CrawlBox|CrawlBox|null|https://github.com/abaykan/CrawlBox.git|git|python,git
 CredSniper|CredSniper|null|https://github.com/ustayready/CredSniper.git|git|python,git
 Crips|Crips|information_gathering|https://github.com/Manisso/Crips.git|git|python,git
 CyberScan|CyberScan|null|https://github.com/medbenali/CyberScan.git|git|python,git
-D-TECT|D-TECT|information_gathering,vulnerability_scanner|https://github.com/shawarkhanethicalhacker/D-TECT.git|git|python,git
 DHCPig|DHCPig|stress_testing|https://github.com/kamorin/DHCPig.git|git|python,git
 DKMC|DKMC|null|https://github.com/Mr-Un1k0d3r/DKMC.git|git|python,git
 DSSS|DSSS|vulnerability_scanner|https://github.com/stamparm/DSSS.git|git|python,git
 DSVW|DSVW|null|https://github.com/stamparm/DSVW.git|git|python,git
 DSXS|DSXS|null|https://github.com/stamparm/DSXS.git|git|python,git
-Devploit|Devploit|information_gathering|https://github.com/joker25000/Devploit.git|git|python,git
 Dr0p1t-Framework|Dr0p1t-Framework|null|https://github.com/D4Vinci/Dr0p1t-Framework.git|git|python,git
 Dracnmap|Dracnmap|null|https://github.com/Screetsec/Dracnmap.git|git|git
 EagleEye|EagleEye|null|https://github.com/ThoughtfulDev/EagleEye.git|git|python,git
@@ -50,18 +48,13 @@ Gloom-Framework|Gloom-Framework|null|https://github.com/StreetSec/Gloom-Framewor
 GoblinWordGenerator|GoblinWordGenerator|null|https://github.com/UndeadSec/GoblinWordGenerator.git|git|python,git
 GoldenEye|GoldenEye|stress_testing|https://github.com/jseidl/GoldenEye.git|git|python,git
 HT-WPS-Breaker|HT-WPS-Breaker|null|https://github.com/SilentGhostX/HT-WPS-Breaker.git|git|git
-HTools|HTools|null|https://github.com/mehedishakeel/HTools.git|git|git
 Hash-Buster|Hash-Buster|password_attack|https://github.com/UltimateHackers/Hash-Buster.git|git|python,git
-Hatch|Hatch|null|https://github.com/MetaChar/Hatch.git|git|python,git
 HiddenEye|HiddenEye|null|https://github.com/DarkSecDevelopers/HiddenEye.git|git|python,git
 Hunner|Hunner|null|https://github.com/b3-v3r/Hunner.git|git|python,git
-IP-FY|IP-FY|information_gathering,ip_tracking|https://github.com/T4P4N/IP-FY.git|git|python,git
-IP-Locator|IP-Locator|null|https://github.com/zanyarjamal/IP-Locator.git|git|perl,git
 IP-Tracer|IP-Tracer|information_gathering,ip_tracking|https://github.com/Rajkumrdusad/IP-Tracer|git|php,git
 IPGeoLocation|IPGeoLocation|ip_tracking|https://github.com/maldevel/IPGeoLocation.git|git|python,git
 InSpy|InSpy|information_gathering|https://github.com/leapsecurity/InSpy.git|git|python,git
 Infoga|Infoga|information_gathering|https://github.com/m4ll0k/Infoga.git|git|python,git
-Instahack|Instahack|null|https://github.com/avramit/Instahack.git|git|python,git
 Intersect-2.5|Intersect-2.5|maintaining_access|https://github.com/deadbits/Intersect-2.5.git|git|python,git
 JohnTheRipper|JohnTheRipper|password_attack|https://github.com/magnumripper/JohnTheRipper.git|git|clang,gcc,g++,git
 KatanaFramework|KatanaFramework|null|https://github.com/PowerScript/KatanaFramework.git|git|python,git
@@ -72,13 +65,11 @@ LITEDDOS|LITEDDOS|ddos|https://github.com/4L13199/LITEDDOS.git|git|python,git
 LITESPAM|LITESPAM|null|https://github.com/4L13199/LITESPAM.git|git|php,git
 Lazymux|Lazymux|null|https://github.com/Gameye98/Lazymux.git|git|python,git
 Leaked|Leaked|null|https://github.com/GitHackTools/Leaked.git|git|python,git
-Mercury|Mercury|null|https://github.com/MetaChar/Mercury.git|git|python,git
 Meterpreter_Paranoid_Mode-SSL|Meterpreter_Paranoid_Mode-SSL|exploitation_tools|https://github.com/r00t-3xp10it/Meterpreter_Paranoid_Mode-SSL.git|git|git
 MyServer|MyServer|web_server|https://github.com/Rajkumrdusad/MyServer.git|git|python,git
 Nethunter-In-Termux|Nethunter-In-Termux|null|https://github.com/Hax4us/Nethunter-In-Termux.git|git|git
 OSIF|OSIF|information_gathering|https://github.com/ciku370/OSIF.git|git|python,git
 PadBuster|PadBuster|web_hacking|https://github.com/AonCyberLabs/PadBuster.git|git|perl,git
-Parat|Parat|null|https://github.com/micle-fm/Parat.git|git|python,git
 Parsero|Parsero|information_gathering|https://github.com/behindthefirewalls/Parsero.git|git|python,git
 PiDense|PiDense|null|https://github.com/WiPi-Hunter/PiDense.git|git|python,git
 Planetwork-DDOS|Planetwork-DDOS|ddos,stress_testing|https://github.com/Hydra7/Planetwork-DDOS.git|git|python,git
@@ -91,14 +82,12 @@ QRLJacking|QRLJacking|null|https://github.com/OWASP/QRLJacking.git|git|python,gi
 RED_HAWK|RED_HAWK|information_gathering,vulnerability_scanner|https://github.com/Tuhinshubhra/RED_HAWK.git|git|php,git
 RTLSDR-Scanner|RTLSDR-Scanner|wireless_testing|https://github.com/EarToEarOak/RTLSDR-Scanner.git|git|python,git
 ReconDog|ReconDog|information_gathering|https://github.com/UltimateHackers/ReconDog.git|git|python,git
-RegRipper2.8|RegRipper2.8|forensics_tools|https://github.com/keydet89/RegRipper2.8.git|git|perl,git
 Remot3d|Remot3d|null|https://github.com/KeepWannabe/Remot3d.git|git|git
 Responder|Responder|sniffing_spoofing|https://github.com/lgandx/Responder.git|git|python,git
 ReverseAPK|ReverseAPK|null|https://github.com/1N3/ReverseAPK.git|git|git
 SCANNER-INURLBR|SCANNER-INURLBR|web_hacking|https://github.com/googleinurl/SCANNER-INURLBR.git|git|php,git
 SET|social-engineer-toolkit|information_gathering,exploitation_tools,password_attack,sniffing_spoofing|https://github.com/trustedsec/social-engineer-toolkit.git|git|python,git
 SH33LL|SH33LL|vulnerability_scanner,web_hacking|https://github.com/LOoLzeC/SH33LL.git|git|python,git
-SMBrute|SMBrute|null|https://github.com/m4ll0k/SMBrute.git|git|python,git
 SecLists|SecLists|password_attack|https://github.com/danielmiessler/SecLists.git|git|php,perl,git
 Simple-Fuzzer|Simple-Fuzzer|vulnerability_scanner|https://github.com/orgcandman/Simple-Fuzzer.git|git|clang,gcc,git
 Sn1per|Sn1per|null|https://github.com/1N3/Sn1per.git|git|python,git
@@ -113,13 +102,9 @@ Th3inspector|Th3inspector|null|https://github.com/Moham3dRiahi/Th3inspector.git|
 The-Eye|The-Eye|null|https://github.com/EgeBalci/The-Eye.git|git|golang,git
 TheFatRat|TheFatRat|null|https://github.com/Screetsec/TheFatRat.git|git|git
 Tool-X|Tool-X|null|https://github.com/Rajkumrdusad/Tool-X.git|git|python,git
-TorStat|TorStat|null|https://github.com/s0cket7/TorStat.git|git|python,git
-Trity|Trity|null|https://github.com/toxic-ig/Trity.git|git|python,git
 Umbrella|Umbrella|null|https://github.com/4w4k3/Umbrella.git|git|git
 Vegile|Vegile|null|https://github.com/Screetsec/Vegile.git|git|git
-WAScan|WAScan|information_gathering,vulnerability_scanner,web_hacking|https://github.com/m4ll0k/WAScan.git|git|python,git
 WP-plugin-scanner|WP-plugin-scanner|web_hacking|https://github.com/mintobit/WP-plugin-scanner.git|git|python,git
-WPSeku|WPSeku|null|https://github.com/m4ll0k/WPSeku.git|git|python,git
 WebScarab|OWASP-WebScarab|web_hacking|https://github.com/OWASP/OWASP-WebScarab.git|git|git
 WebXploiter|WebXploiter|web_hacking,exploitation_tools|https://github.com/a0xnirudh/WebXploiter.git|git|python,git
 WhatWeb|WhatWeb|web_hacking|https://github.com/urbanadventurer/WhatWeb.git|git|python,git
@@ -137,7 +122,6 @@ aircrack-ng|aircrack-ng|wireless_testing|null|package_manager|null
 airgeddon|airgeddon|wireless_testing|https://github.com/v1s1t0r1sh3r3/airgeddon.git|git|git
 angryFuzzer|angryFuzzer|null|https://github.com/ihebski/angryFuzzer.git|git|python,git
 apache2|apache2|web_server,package|null|package_manager|null
-apt2|apt2|information_gathering|https://github.com/MooseDojo/apt2.git|git|python,git
 arch-linux|setupTermuxArch.sh|termux_os|https://raw.githubusercontent.com/sdrausty/TermuxArch/master/setupTermuxArch.sh|curl|proot,curl
 arp-scan|arp-scan|information_gathering|https://github.com/royhills/arp-scan.git|git|clang,gcc,git
 avet|avet|null|https://github.com/govolution/avet.git|git|clang,gcc,git
@@ -170,7 +154,6 @@ curl|curl|package|null|package_manager|null
 c|clang|programming_language|null|package_manager|null
 dbd|dbd|maintaining_access|https://github.com/gitdurandal/dbd.git|git|clang,gcc,git
 deblaze|deblaze|web_hacking|https://github.com/SpiderLabs/deblaze.git|git|clang,gcc,python,git
-dedsploit|dedsploit|null|https://github.com/ex0dus-0x/dedsploit.git|git|python,git
 demiguise|demiguise|null|https://github.com/nccgroup/demiguise.git|git|python,git
 distorm|distorm|forensics_tools|https://github.com/gdabah/distorm.git|git|clang,gcc,python,git
 djangohunter|djangohunter|null|https://github.com/6IX7ine/djangohunter.git|git|python,git
@@ -255,7 +238,6 @@ mitmproxy|mitmproxy|sniffing_spoofing|https://github.com/mitmproxy/mitmproxy.git
 morpheus|morpheus|null|https://github.com/r00t-3xp10it/morpheus.git|git|python,git
 msfpc|msfpc|exploitation_tools|https://github.com/g0tmi1k/msfpc.git|git|git
 multimon-ng|multimon-ng|wireless_testing|https://github.com/EliasOenal/multimon-ng.git|git|python,clang,gcc,git
-nWatch|nWatch|null|https://github.com/s0cket7/nWatch.git|git|python,git
 nano|nano|package|null|package_manager|null
 netattack2|netattack2|wireless_testing|https://github.com/chrizator/netattack2.git|git|python,git
 netattack|netattack|wireless_testing|https://github.com/chrizator/netattack.git|git|python,git
@@ -282,7 +264,6 @@ powerfuzzer|powerfuzzer|vulnerability_scanner|https://gitlab.com/marcinguy/power
 proxystrike|proxystrike|web_hacking|https://github.com/qunxyz/proxystrike.git|git|python,git
 pupy|pupy|null|https://github.com/n1nj4sec/pupy|git|python,git
 pwnat|pwnat|maintaining_access|https://github.com/samyk/pwnat.git|git|clang,gcc,git
-pyPISHER|pyPISHER|sniffing_spoofing|https://github.com/Renato-Silva/pyPISHER.git|git|python,git
 pybluez|pybluez|null|https://github.com/karulis/pybluez.git|git|python,git
 pydictor|pydictor|null|https://github.com/LandGrey/pydictor.git|git|python,git
 python|python|programming_language|null|package_manager|null
@@ -306,7 +287,6 @@ sipvicious|sipvicious|sniffing_spoofing|https://github.com/EnableSecurity/sipvic
 skipfish|skipfish|web_hacking|https://gitlab.com/kalilinux/packages/skipfish.git|git|clang,gcc,git
 slowhttptest|slowhttptest|stress_testing|https://github.com/shekyan/slowhttptest.git|git|clang,gcc,g++,git
 slowloris|slowloris|ddos,stress_testing|https://github.com/gkbrk/slowloris.git|git|python,git
-smap|smap|web_hacking|https://github.com/s0cket7/smap|git|python,git
 smbmap|smbmap|information_gathering|https://github.com/ShawnDEvans/smbmap.git|git|python,git
 sniffjoke|sniffjoke|sniffing_spoofing|https://github.com/vecna/sniffjoke.git|git|clang,gcc,g++,git
 social-engineer-toolkit|social-engineer-toolkit|information_gathering,exploitation_tools,password_attack,sniffing_spoofing|https://github.com/trustedsec/social-engineer-toolkit.git|git|python,git
@@ -321,7 +301,6 @@ sslyze|sslyze|information_gathering|https://github.com/iSECPartners/sslyze.git|g
 subscraper|subscraper|null|https://github.com/m8r0wn/subscraper.git|git|python,git
 termineter|termineter|stress_testing|https://github.com/securestate/termineter.git|git|python,git
 termux-fedora|termux-fedora|termux_os|https://github.com/nmilosev/termux-fedora.git|git|proot,git
-termux-lazysqlmap|termux-lazysqlmap|null|https://github.com/verluchie/termux-lazysqlmap.git|git|git
 termux-ubuntu|termux-ubuntu|termux_os|https://github.com/Neo-Oli/termux-ubuntu.git|git|proot,git
 thc-ipv6|thc-ipv6|information_gathering,vulnerability_scanner,exploitation_tools|https://github.com/vanhauser-thc/thc-ipv6.git|git|clang,gcc,git
 the-backdoor-factory|the-backdoor-factory|exploitation_tools|https://github.com/secretsquirrel/the-backdoor-factory.git|git|python,git
@@ -362,7 +341,6 @@ xplico|xplico|forensics_tools|https://gitlab.com/kalilinux/packages/xplico.git|g
 xspy|xspy|sniffing_spoofing|https://github.com/mnp/xspy.git|git|clang,gcc,git
 xsser|xsser|web_hacking|https://github.com/epsylon/xsser.git|git|python,git
 yersinia|yersinia|vulnerability_scanner,exploitation_tools|https://github.com/tomac/yersinia.git|git|clang,gcc,git
-zambie|zambie|null|https://github.com/zanyarjamal/zambie.git|git|python,git
 zaproxy|zaproxy|web_hacking|https://github.com/zaproxy/zaproxy.git|git|python,php,git
 zarp|zarp|null|https://github.com/hatRiot/zarp.git|git|python,git
 zip|zip|package|null|package_manager|null
@@ -389,3 +367,5 @@ katoolin|katooling|null|https://github.com/LionSec/katoolin.git|git|python2,git
 SARA|SARA|null|https://github.com/termuxhackers-id/SARA.git|git|python,git
 zphisher|zphisher|information_gathering|https://github.com/htr-tech/zphisher.git|git|php,nodejs,git
 check-ip|check-ip|null|https://github.com/1RaY-1/check-ip.git|git|python,git
+Mr-DDos|Mr-DDos|ddos|https://github.com/OnlineHacKing/Mr-DDos.git|git|python2,perl,git
+MHDDoS|MHDDoS|ddos|https://github.com/MHProDev/MHDDoS.git|git|python,git


### PR DESCRIPTION
1st change:
Remove tools that no longer exist.
Now there is nothing on this links:

https://github.com/MooseDojo/apt2.git
https://github.com/shawarkhanethicalhacker/D-TECT.git
https://github.com/ex0dus-0x/dedsploit.git
https://github.com/joker25000/Devploit.git
https://github.com/MetaChar/Hatch.git
https://github.com/mehedishakeel/HTools.git
https://github.com/avramit/Instahack.git
https://github.com/T4P4N/IP-FY.git
https://github.com/zanyarjamal/IP-Locator.git
https://github.com/MetaChar/Mercury.git
https://github.com/s0cket7/nWatch.git
https://github.com/micle-fm/Parat.git
https://github.com/Renato-Silva/pyPISHER.git
https://github.com/keydet89/RegRipper2.8.git
https://github.com/s0cket7/smap
https://github.com/m4ll0k/SMBrute.git
https://github.com/verluchie/termux-lazysqlmap.git
https://github.com/s0cket7/TorStat.git
https://github.com/toxic-ig/Trity.git
https://github.com/m4ll0k/WAScan.git
https://github.com/m4ll0k/WPSeku.git
https://github.com/zanyarjamal/zambie.git

So I would remove them.

2nd change:
Add some tools (MHDDoS and MrDDoS).
