### PR TITLE
Patch

### DIFF
--- a/data/tools.dat
+++ b/data/tools.dat
@@ -48,7 +48,7 @@ GoblinWordGenerator|GoblinWordGenerator|null|https://github.com/UndeadSec/Goblin
 GoldenEye|GoldenEye|stress_testing|https://github.com/jseidl/GoldenEye.git|git|python,git
 HT-WPS-Breaker|HT-WPS-Breaker|null|https://github.com/SilentGhostX/HT-WPS-Breaker.git|git|git
 Hash-Buster|Hash-Buster|password_attack|https://github.com/UltimateHackers/Hash-Buster.git|git|python,git
-HiddenEye|HiddenEye|null|https://github.com/DarkSecDevelopers/HiddenEye.git|git|python,git
+HiddenEye|HiddenEye|null|https://gitlab.com/An0nUD4Y/hiddeneye|git|python,git
 Hunner|Hunner|null|https://github.com/b3-v3r/Hunner.git|git|python,git
 IP-Tracer|IP-Tracer|information_gathering,ip_tracking|https://github.com/Rajkumrdusad/IP-Tracer|git|php,git
 IPGeoLocation|IPGeoLocation|ip_tracking|https://github.com/maldevel/IPGeoLocation.git|git|python,git
@@ -351,7 +351,7 @@ edb-debugger|edb-debugger|reverse_engineering|null|package_manager|null
 zVirus-Gen|zVirus-Gen|null|https://github.com/ZechBron/zVirus-Gen.git|git|git
 nasm|nasm|programming_language|null|package_manager|null
 Keylogger|Keylogger|null|https://github.com/aydinnyunus/Keylogger.git|git|python,git
-XLR8_BOMBER|XLR8_BOMBER|null|https://github.com/anubhavanonymous/XLR8_BOMBER.git|git|git
+XLR8_BOMBER|XLR8_BOMBER|null|https://github.com/sonudohare85/XLR8_BOMBER|git|git
 b0mb3r|b0mb3r|null|https://github.com/Denishnc/b0mb3r.git|git|python,git
 Tbomb|Tbomb|null|https://github.com/TheSpeedX/TBomb.git|git|python,git
 flashsploit|flashsploit|exploitation_tools|https://github.com/thewhiteh4t/flashsploit.git|git|python,git


### PR DESCRIPTION
Looks like @DarkSecDevelopers and @anubhavanonymous have been removed, so changed link for HiddenEye and XLR8_BOMBRER (because this tools belong to this accounts) to still be able to install them (but from other source).